### PR TITLE
feat: Enhance error handling for brand, date, and product ID parsing

### DIFF
--- a/domain/src/main/java/com/gft/inditex/domain/exception/NotFoundException.java
+++ b/domain/src/main/java/com/gft/inditex/domain/exception/NotFoundException.java
@@ -1,0 +1,7 @@
+package com.gft.inditex.domain.exception;
+
+public class NotFoundException extends RuntimeException {
+    public NotFoundException(String message) {
+        super(message);
+    }
+}

--- a/persistence/src/main/java/com/gft/inditex/persistence/infra/adapters/out/PricePersistenceImpl.java
+++ b/persistence/src/main/java/com/gft/inditex/persistence/infra/adapters/out/PricePersistenceImpl.java
@@ -2,9 +2,11 @@ package com.gft.inditex.persistence.infra.adapters.out;
 
 import com.gft.inditex.domain.Brands;
 import com.gft.inditex.domain.Price;
+import com.gft.inditex.domain.exception.NotFoundException;
 import com.gft.inditex.domain.ports.out.PricePersistence;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
 
 import java.time.LocalDateTime;
 import java.util.concurrent.CompletableFuture;
@@ -21,6 +23,7 @@ public class PricePersistenceImpl implements PricePersistence {
     public CompletableFuture<Price> getPricesForZaraBrand(LocalDateTime applicationDate, Integer productId, Brands brand) {
         return repository
                 .findByBrandIdAndApplicationDateAndProductId(brand.getValue(), applicationDate, productId)
+                .switchIfEmpty(Mono.error(new NotFoundException("Entity not found for brand: " + brand + ", applicationDate: " + applicationDate + ", productId: " + productId)))
                 .map(priceMapper::mapFromEntityToPrices)
                 .toFuture();  // Convert the Mono<Price> to CompletableFuture<Price>
     }

--- a/persistence/src/test/java/com/gft/inditex/persistence/infra/adapters/out/PricePersistenceImplTest.java
+++ b/persistence/src/test/java/com/gft/inditex/persistence/infra/adapters/out/PricePersistenceImplTest.java
@@ -3,6 +3,7 @@ package com.gft.inditex.persistence.infra.adapters.out;
 
 import com.gft.inditex.domain.Brands;
 import com.gft.inditex.domain.Price;
+import com.gft.inditex.domain.exception.NotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -13,6 +14,7 @@ import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import java.time.LocalDateTime;
+import java.util.concurrent.CompletableFuture;
 
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -41,8 +43,7 @@ class PricePersistenceImplTest {
         mockEntity.setProductId(productId);
         mockEntity.setBrandId(1);
         mockEntity.setCurrency("EUR");
-        Mockito.when(repository.findByBrandIdAndApplicationDateAndProductId(Brands.ZARA.getValue(), applicationDate, productId))
-                .thenReturn(Mono.just(mockEntity));
+
 
         // When
         Mono<Price> resultMono =Mono.fromFuture(() -> adapter.getPricesForZaraBrand(applicationDate, productId, Brands.ZARA));
@@ -57,4 +58,25 @@ class PricePersistenceImplTest {
         Mockito.verify(repository, Mockito.times(1)).findByBrandIdAndApplicationDateAndProductId(Brands.ZARA.getValue(), applicationDate, productId);
 
     }
-}
+
+    @Test
+    void should_throw_NotFoundException_when_entity_not_found_in_service() {
+        // Given
+        LocalDateTime applicationDate = LocalDateTime.now();
+        Integer productId = 56365;
+
+        Mockito.when(repository.findByBrandIdAndApplicationDateAndProductId(Brands.ZARA.getValue(), applicationDate, productId))
+                .thenReturn(Mono.empty());
+
+        // When
+        CompletableFuture<Price> resultFuture = adapter.getPricesForZaraBrand(applicationDate, productId, Brands.ZARA);
+
+        // Convert CompletableFuture to Mono for StepVerifier
+        Mono<Price> resultMono = Mono.fromFuture(() -> resultFuture);
+
+        // Then
+        StepVerifier.create(resultMono)
+                .expectError(NotFoundException.class)
+                .verify();
+    }
+   }

--- a/persistence/src/test/java/com/gft/inditex/persistence/infra/adapters/out/SpringPricesRepositoryTest.java
+++ b/persistence/src/test/java/com/gft/inditex/persistence/infra/adapters/out/SpringPricesRepositoryTest.java
@@ -77,4 +77,6 @@ class SpringPricesRepositoryTest {
                 )
                 .verifyComplete();
     }
+
+
 }

--- a/src/main/java/com/gft/inditex/finalprice/infra/adapters/in/PriceHandler.java
+++ b/src/main/java/com/gft/inditex/finalprice/infra/adapters/in/PriceHandler.java
@@ -3,9 +3,11 @@ package com.gft.inditex.finalprice.infra.adapters.in;
 import com.gft.inditex.domain.Brands;
 import com.gft.inditex.domain.RequestData;
 import com.gft.inditex.domain.ResponseData;
+import com.gft.inditex.domain.exception.NotFoundException;
 import com.gft.inditex.domain.ports.in.RequestPriceResource;
 import com.gft.inditex.domain.ports.out.RequestPrice;
 import com.gft.inditex.finalprice.application.ConversionHandler;
+import com.gft.inditex.finalprice.infra.adapters.in.exceptions.InvalidBrandException;
 import com.gft.inditex.finalprice.infra.adapters.in.exceptions.InvalidDateFormatException;
 import com.gft.inditex.finalprice.infra.adapters.in.exceptions.InvalidProductIdException;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +21,9 @@ import reactor.core.publisher.Mono;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 
@@ -26,32 +31,63 @@ import java.util.concurrent.CompletionException;
 @RequiredArgsConstructor
 public class PriceHandler implements RequestPriceResource {
 
+    public static final String BRAND = "brand";
+    public static final String PRODUCT_ID = "product_id";
+    public static final String APPLICATION_DATE = "application_date";
+    public static final String YYYY_MM_DD_HH_MM_SS = "yyyy-MM-dd-HH.mm.ss";
+    public static final String INVALID_DATE_FORMAT_MESSAGE = "Invalid date format. Please use 'yyyy-MM-dd-HH.mm.ss'.";
+    public static final String INVALID_PRODUCT_ID_FORMAT_MESSAGE = "Invalid product ID format. Please provide a valid number.";
+    public static final String INVALID_BRAND_NAME_MESSAGE = "Invalid brand name provided.";
     private final RequestPrice requestPrice;
     private final ConversionHandler conversionHandler;
+
     public Mono<ServerResponse> handleRequestPrice(ServerRequest serverRequest) {
         RequestData requestData = this.conversionHandler.fromServerRequest(serverRequest);
-        return Mono.fromFuture(() -> requestPrice(requestData))
-                .flatMap(ConversionHandler::toServerResponse)  // Adjusted this line
-                .onErrorResume(ex -> ServerResponse.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                        .body(BodyInserters.fromValue(ex.getMessage())));
+
+        return Mono.defer(() -> Mono.fromFuture(() -> requestPrice(requestData)))
+                .flatMap(ConversionHandler::toServerResponse)
+                .onErrorResume(ex -> {
+                    if (ex instanceof InvalidDateFormatException || ex instanceof InvalidProductIdException || ex instanceof InvalidBrandException) {
+                        return generateErrorResponseForDirectExceptions(ex);
+                    } else if (ex instanceof CompletionException completionException) {
+                        return generateErrorResponse(completionException);
+                    }
+                    return ServerResponse.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                            .body(BodyInserters.fromValue(ex.getMessage()));
+                });
     }
+
+    private Mono<ServerResponse> generateErrorResponseForDirectExceptions(Throwable ex) {
+        return ServerResponse.status(HttpStatus.BAD_REQUEST).body(BodyInserters.fromValue(ex.getMessage()));
+    }
+
+    private Mono<ServerResponse> generateErrorResponse(CompletionException completionEx) {
+        Throwable cause = completionEx.getCause();
+
+        Map<Class<? extends Throwable>, HttpStatus> errorMapping = new HashMap<>();
+        errorMapping.put(NotFoundException.class, HttpStatus.BAD_REQUEST);
+        errorMapping.put(InvalidDateFormatException.class, HttpStatus.BAD_REQUEST);
+        errorMapping.put(InvalidProductIdException.class, HttpStatus.BAD_REQUEST);
+
+        return Optional.ofNullable(errorMapping.get(cause.getClass()))
+                .map(status -> ServerResponse.status(status).body(BodyInserters.fromValue(cause.getMessage())))
+                .orElseGet(() -> ServerResponse.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                        .body(BodyInserters.fromValue(cause.getMessage())));
+    }
+
     @Override
     public CompletableFuture<ResponseData> requestPrice(RequestData requestData) {
         try {
             LocalDateTime applicationDate = parseApplicationDate(requestData);
             int productId = parseProductId(requestData);
-            Brands brand = Brands.valueOf(requestData.getPathVariables().get("brand").toUpperCase());
+            Brands brand = parseBrand(requestData);
 
             return this.requestPrice.execute(applicationDate, productId, brand)
                     .thenApply(price -> {
                         PriceDTO priceDTO = PriceDTO.mapDomainToDTO(price);
                         return this.conversionHandler.fromPriceDTO(priceDTO);
-                    })
-                    .exceptionally(ex -> {
-                        throw new CompletionException(ex);
                     });
-
-        } catch (InvalidDateFormatException | InvalidProductIdException e) {
+        } catch (InvalidDateFormatException | InvalidProductIdException | InvalidBrandException e) {
             CompletableFuture<ResponseData> errorFuture = new CompletableFuture<>();
             errorFuture.completeExceptionally(e);
             return errorFuture;
@@ -60,17 +96,24 @@ public class PriceHandler implements RequestPriceResource {
 
     private LocalDateTime parseApplicationDate(RequestData requestData) throws InvalidDateFormatException {
         try {
-            return LocalDateTime.parse(requestData.getPathVariables().get("application_date"), DateTimeFormatter.ofPattern("yyyy-MM-dd-HH.mm.ss"));
+            return LocalDateTime.parse(requestData.getPathVariables().get(APPLICATION_DATE), DateTimeFormatter.ofPattern(YYYY_MM_DD_HH_MM_SS));
         } catch (DateTimeParseException e) {
-            throw new InvalidDateFormatException("Invalid date format. Please use 'yyyy-MM-dd-HH.mm.ss'.");
+            throw new InvalidDateFormatException(INVALID_DATE_FORMAT_MESSAGE);
         }
     }
 
     private int parseProductId(RequestData requestData) throws InvalidProductIdException {
         try {
-            return Integer.parseInt(requestData.getPathVariables().get("product_id"));
+            return Integer.parseInt(requestData.getPathVariables().get(PRODUCT_ID));
         } catch (NumberFormatException e) {
-            throw new InvalidProductIdException("Invalid product ID format. Please provide a valid number.");
+            throw new InvalidProductIdException(INVALID_PRODUCT_ID_FORMAT_MESSAGE);
+        }
+    }
+    private Brands parseBrand(RequestData requestData) throws InvalidBrandException {
+        try {
+            return Brands.valueOf(requestData.getPathVariables().get(BRAND).toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new InvalidBrandException(INVALID_BRAND_NAME_MESSAGE);
         }
     }
 }

--- a/src/main/java/com/gft/inditex/finalprice/infra/adapters/in/exceptions/InvalidBrandException.java
+++ b/src/main/java/com/gft/inditex/finalprice/infra/adapters/in/exceptions/InvalidBrandException.java
@@ -1,0 +1,7 @@
+package com.gft.inditex.finalprice.infra.adapters.in.exceptions;
+
+public class InvalidBrandException extends RuntimeException {
+    public InvalidBrandException(String message) {
+        super(message);
+    }
+}

--- a/src/test/java/com/gft/inditex/finalprice/infra/in/PriceHandlerTest.java
+++ b/src/test/java/com/gft/inditex/finalprice/infra/in/PriceHandlerTest.java
@@ -5,6 +5,7 @@ import com.gft.inditex.finalprice.FinalPriceApplication;
 import com.gft.inditex.domain.ports.out.RequestPrice;
 import com.gft.inditex.finalprice.config.TestConfig;
 import com.gft.inditex.finalprice.infra.adapters.in.PriceDTO;
+import com.gft.inditex.finalprice.infra.adapters.in.PriceHandler;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.r2dbc.AutoConfigureDataR2dbc;
@@ -56,8 +57,8 @@ class PriceHandlerTest {
         webClient.get()
                 .uri("/getPrice/invalid_date/123/ZARA")
                 .exchange()
-                .expectStatus().is5xxServerError()
-                .expectBody(String.class).isEqualTo("Invalid date format. Please use 'yyyy-MM-dd-HH.mm.ss'.");
+                .expectStatus().is4xxClientError()
+                .expectBody(String.class).isEqualTo(PriceHandler.INVALID_DATE_FORMAT_MESSAGE);
     }
     @Test
     void should_return_error_for_a_invalid_productId() {
@@ -66,8 +67,20 @@ class PriceHandlerTest {
         webClient.get()
                 .uri("/getPrice/" + date.format(DateTimeFormatter.ofPattern("yyyy-MM-dd-HH.mm.ss")) + "/invalid_id/ZARA")
                 .exchange()
-                .expectStatus().is5xxServerError()
-                .expectBody(String.class).isEqualTo("Invalid product ID format. Please provide a valid number.");
+                .expectStatus().is4xxClientError()
+                .expectBody(String.class).isEqualTo(PriceHandler.INVALID_PRODUCT_ID_FORMAT_MESSAGE);
+
+    }
+
+    @Test
+    void should_return_error_for_a_invalid_brand() {
+        LocalDateTime date = LocalDateTime.now();
+
+        webClient.get()
+                .uri("/getPrice/" + date.format(DateTimeFormatter.ofPattern("yyyy-MM-dd-HH.mm.ss")) +  "/123/ZAARA")
+                .exchange()
+                .expectStatus().is4xxClientError()
+                .expectBody(String.class).isEqualTo(PriceHandler.INVALID_BRAND_NAME_MESSAGE);
 
     }
 


### PR DESCRIPTION
- Add dedicated parsing method for brand names with error handling.
- Throw specific exceptions (`InvalidBrandException`, `InvalidDateFormatException`, and `InvalidProductIdException`) for more granular error feedback.
- Improve the response generation mechanism to map specific exceptions to appropriate HTTP status codes.